### PR TITLE
#7 - starting raffle without selecting events raises exception

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -5,9 +5,9 @@ framework:
     #http_method_override: true
     #trusted_hosts: ~
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
-    #session:
-    #    # The native PHP session handler will be used
-    #    handler_id: ~
+    session:
+        # The native PHP session handler will be used
+        handler_id: ~
     #esi: ~
     #fragments: ~
     php_errors:

--- a/templates/Raffle/index.html.twig
+++ b/templates/Raffle/index.html.twig
@@ -2,9 +2,34 @@
 
 {% block body %}
 
+
+
+
     <div class="row">
         <div class="col-lg-5 text-white " style="text-shadow: 0 0 10px #000;font-size: 50px;">
             <br/><br/><br/><br/>
+
+            <div>
+
+
+                {% if app.session %}
+                    {% for flashMessage in app.session.flashbag.get('error') %}
+                        <div class="col-lg-5 text-white " style="text-shadow: 0 0 10px #bd2130;font-size: 50px;">
+                            {{ flashMessage }}
+                        </div>
+                    {% endfor %}
+
+                    {% for flashMessage in app.session.flashbag.get('notice') %}
+                        <div class="col-lg-5 text-white " style="text-shadow: 0 0 10px #005cbf;font-size: 50px;">
+                        {{ flashMessage }}
+                        </div>
+                    {% endfor %}
+                {% endif %}
+
+            </div>
+
+
+
 
             <form action="/raffle/start" method="POST">
                 <table class="table table-condensed" style="background: rgba(0, 0, 0, 0.74)">
@@ -28,5 +53,6 @@
             </form>
         </div>
     </div>
+
 
 {% endblock %}

--- a/templates/Raffle/show.html.twig
+++ b/templates/Raffle/show.html.twig
@@ -9,6 +9,18 @@
             </div>
         {% endfor %}
     </div>
+
+    <div class="row text-center" style="height: 20px;">
+
+    </div>
+
+    <div class="row text-center" style="background: rgba(100, 0, 0, 0.74)">
+        {% for comment in raffle.commentsNotEligibleForRaffling %}
+            <div class="col-md-3 text-white" style="text-shadow: 0 0 10px #000;font-size: 40px;">
+                {{ comment.user.displayName }}
+            </div>
+        {% endfor %}
+    </div>
     <div class="row text-center text-white" style="margin-left:0px; position: absolute; bottom: 50px; width: 100%;
     background: rgba(0, 0, 0, 0.74)">
         <div class="col-md-4">
@@ -22,7 +34,9 @@
             {% endif %}
         </div>
         <div class="col-md-4">
-            There are {{ raffle.commentsEligibleForRaffling | length }} eligible!
+            There are {{ raffle.commentsEligibleForRaffling | length }} eligible comments!
+            <br>
+            There are {{ raffle.commentsNotEligibleForRaffling | length }} non-eligible comments!
         </div>
     </div>
 


### PR DESCRIPTION
Trying to run a raffle with no events selected crashed the frontend app, because backend didn't return a sensible raffle id in such cases.

This analyzes the http response code and reroutes to appropriate page, and displays flash message notifications as needed.
 
Closes #7 

**NOTE: DEPENDS ON [open PR on raffler backend ](https://github.com/zgphp/joindin-raffler-backend/pull/152) AND WILL NOT WORK WITHOUT IT!**